### PR TITLE
Parse params in script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,34 +138,41 @@ jobs:
           ls -lR report_output_dir
           ls -lR summary_output_dir
 
-      # https://github.com/marketplace/actions/azure-cli-action#workflow-to-execute-an-azure-cli-script-of-a-specific-cli-version
-      - name: Upload results to blob store
-        id: upload
-        uses: azure/CLI@v2
-        env:
-          CONFIG_NAME: ${{ inputs.config-name }}
-          GITHUB_REF_NAME: ${{ github.ref_name}}
-          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
-          REPORT_OUTPUT_DIR: report_output_dir
-          SUMMARY_OUTPUT_DIR: summary_output_dir
-          RESULTS_URL: ${{ inputs.results-url }}
+      - name: Upload report to Blob store 
+        id: upload-report
+        uses: RMI-PACTA/actions/actions/azure/blob-copy@main
         with:
-          inlineScript: |
-            unique_directory="$RESULTS_URL/$GITHUB_REF_NAME/$GITHUB_RUN_NUMBER/$GITHUB_RUN_ATTEMPT/$CONFIG_NAME"
-            az storage copy \
-              --source "$REPORT_OUTPUT_DIR"/* \
-              --destination "$unique_directory" \
-              --recursive
-            echo "report-url=${unique_directory}/report/index.html" >> "$GITHUB_OUTPUT"
+          source: report_output_dir
+          destination: ${{ inputs.results-url }}/${{ github.ref_name }}/${{ github.run_number }}/${{ github.run_attempt }}/${{ inputs.config-name }}
+          overwrite: false
 
-            az storage copy \
-              --source "$SUMMARY_OUTPUT_DIR"/* \
-              --destination "$unique_directory" \
-              --recursive
-            summary_files="$(ls $SUMMARY_OUTPUT_DIR/executive_summary/*.pdf)"
-            echo "summary-url=${unique_directory}/executive_summary/$summary_files" >> "$GITHUB_OUTPUT"
+      - name: Upload summary to Blob store 
+        id: upload-summary
+        uses: RMI-PACTA/actions/actions/azure/blob-copy@main
+        with:
+          source: summary_output_dir
+          destination: ${{ inputs.results-url }}/${{ github.ref_name }}/${{ github.run_number }}/${{ github.run_attempt }}/${{ inputs.config-name }}
+          overwrite: false
 
+      - name: Export Outputs
+        id: export-outputs
+        env:
+          REPORT_UPLOADED_FILES: ${{ steps.upload-report.outputs.destination-files }}
+          SUMMARY_UPLOADED_FILES: ${{ steps.upload-summary.outputs.destination-files }}
+        run: |
+
+          REPORT_URL="$(
+            echo "$REPORT_UPLOADED_FILES" | jq -rc '. [] | match(".*index.html$") | .string'
+          )"
+          echo "report-url=$REPORT_URL"
+          echo "report-url=$REPORT_URL" >> "$GITHUB_OUTPUT"
+
+          SUMMARY_URL="$(
+            echo "$SUMMARY_UPLOADED_FILES" | jq -rc '. [] | match(".*.pdf$") | .string'
+          )"
+          echo "summary-url=$SUMMARY_URL"
+          echo "summary-url=$SUMMARY_URL" >> "$GITHUB_OUTPUT"
+          
       - name: Prepare comment artifact
         id: prepare-artifact
         env:
@@ -173,8 +180,8 @@ jobs:
           config_name: ${{ inputs.config-name }}
           full_image_name: ${{ inputs.full-image-name }}
           git_sha: ${{ github.event.pull_request.head.sha }}
-          report_url: ${{ steps.upload.outputs.report-url }}
-          summary_url: ${{ steps.upload.outputs.summary-url }}
+          report_url: ${{ steps.export-outputs.outputs.report-url }}
+          summary_url: ${{ steps.export-outputs.outputs.summary-url }}
         run: |
           mkdir -p /tmp/comment-json
           json_filename="$( \

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: workflow.pacta.report
 Title: Reporting functionality for PACTA
-Version: 0.0.0.9005
+Version: 0.0.0.9006
 Authors@R: 
     c(person(given = "Alex",
              family = "Axthelm",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,8 +27,10 @@ Imports:
     pacta.executive.summary,
     pacta.portfolio.report,
     pacta.portfolio.utils,
+    pacta.workflow.utils,
     readr
 Remotes:
     RMI-PACTA/pacta.executive.summary,
     RMI-PACTA/pacta.portfolio.report,
     RMI-PACTA/pacta.portfolio.utils,
+    RMI-PACTA/pacta.workflow.utils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ RoxygenNote: 7.3.2
 Imports:
     dplyr,
     jsonlite,
-    jsonvalidate,
     logger,
     pacta.executive.summary,
     pacta.portfolio.report,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,10 +27,8 @@ Imports:
     pacta.executive.summary,
     pacta.portfolio.report,
     pacta.portfolio.utils,
-    pacta.workflow.utils,
     readr
 Remotes:
     RMI-PACTA/pacta.executive.summary,
     RMI-PACTA/pacta.portfolio.report,
     RMI-PACTA/pacta.portfolio.utils,
-    RMI-PACTA/pacta.workflow.utils

--- a/R/run_pacta_reporting_process.R
+++ b/R/run_pacta_reporting_process.R
@@ -21,7 +21,7 @@ run_pacta_reporting_process <- function(
     log_error("REPORT_OUTPUT_DIR not set.")
     stop("REPORT_OUTPUT_DIR not set.")
   } else {
-    if (!pacta.portfolio.utils::check_dir_writable(report_output_dir)) {
+    if (!pacta.workflow.utils::check_dir_writable(report_output_dir)) {
       log_warn("Directory \"{report_output_dir}\" is not writable.")
       stop("Directory \"{report_output_dir}\" is not writable.")
     }
@@ -30,7 +30,7 @@ run_pacta_reporting_process <- function(
     log_error("SUMMARY_OUTPUT_DIR not set.")
     stop("SUMMARY_OUTPUT_DIR not set.")
   } else {
-    if (!pacta.portfolio.utils::check_dir_writable(summary_output_dir)) {
+    if (!pacta.workflow.utils::check_dir_writable(summary_output_dir)) {
       log_warn("Directory \"{report_output_dir}\" is not writable.")
       stop("Directory \"{report_output_dir}\" is not writable.")
     }

--- a/R/run_pacta_reporting_process.R
+++ b/R/run_pacta_reporting_process.R
@@ -288,12 +288,12 @@ run_pacta_reporting_process <- function(
   )
 
   log_debug("Loading index equity portfolio results.")
-  indices_equity_results_portfolio_path <- file.path(benchmarks_dir, "Indices_equity_results_portfolio.rds")
-  indices_equity_results_portfolio <- readRDS(indices_equity_results_portfolio_path)
+  indices_equity_results_port_path <- file.path(benchmarks_dir, "Indices_equity_results_portfolio.rds")
+  indices_equity_results_portfolio <- readRDS(indices_equity_results_port_path)
 
   log_debug("Loading index bonds portfolio results.")
-  indices_bonds_results_portfolio_path <- file.path(benchmarks_dir, "Indices_bonds_results_portfolio.rds")
-  indices_bonds_results_portfolio <- readRDS(indices_bonds_results_portfolio_path)
+  indices_bonds_results_port_path <- file.path(benchmarks_dir, "Indices_bonds_results_portfolio.rds")
+  indices_bonds_results_portfolio <- readRDS(indices_bonds_results_port_path)
 
   # create interactive report ----------------------------------------------------
 
@@ -383,8 +383,8 @@ run_pacta_reporting_process <- function(
           peers_bonds_results_portfolio_path,
           peers_equity_results_user_path,
           peers_bonds_results_user_path,
-          indices_equity_results_portfolio_path,
-          indices_bonds_results_portfolio_path
+          indices_equity_results_port_path,
+          indices_bonds_results_port_path
         )
       ),
       output_files = c(
@@ -392,13 +392,13 @@ run_pacta_reporting_process <- function(
           report_output_dir,
           full.names = TRUE,
           recursive = TRUE
-          ),
+        ),
         list.files(
           summary_output_dir,
           full.names = TRUE,
           recursive = TRUE
         )
-        ),
+      ),
       params = params
     )
   )

--- a/R/run_pacta_reporting_process.R
+++ b/R/run_pacta_reporting_process.R
@@ -1,5 +1,5 @@
 run_pacta_reporting_process <- function(
-  raw_params = commandArgs(trailingOnly = TRUE),
+  params,
   analysis_output_dir = Sys.getenv("ANALYSIS_OUTPUT_DIR"),
   benchmarks_dir = Sys.getenv("BENCHMARKS_DIR"),
   report_output_dir = Sys.getenv("REPORT_OUTPUT_DIR"),
@@ -38,52 +38,7 @@ run_pacta_reporting_process <- function(
     stop("SCORE_CARD_DIR not set.")
   }
 
-  # defaulting to WARN to maintain current (silent) behavior.
-  logger::log_threshold(Sys.getenv("LOG_LEVEL", "INFO"))
-  logger::log_formatter(logger::formatter_glue)
-
-  # -------------------------------------------------------------------------
-
   log_info("Starting portfolio report process")
-
-  # Read Params
-  log_trace("Processing input parameters.")
-  if (length(raw_params) == 0L || all(raw_params == "")) {
-    log_error("No parameters specified.")
-  }
-
-  log_trace("Validating raw input parameters.")
-  raw_input_validation_results <- jsonvalidate::json_validate(
-    json = raw_params,
-    schema = system.file(
-      "extdata", "schema", "rawParameters.json",
-      package = "workflow.pacta.report"
-    ),
-    verbose = TRUE,
-    greedy = FALSE,
-    engine = "ajv"
-  )
-  if (raw_input_validation_results) {
-    log_trace("Raw input parameters are valid.")
-  } else {
-    log_error(
-      "Invalid raw input parameters. ",
-      "Must include \"inherit\" key, or match full schema."
-    )
-    stop("Invalid raw input parameters.")
-  }
-
-  params <- pacta.workflow.utils::parse_params(
-    json = raw_params,
-    inheritence_search_paths = system.file(
-      "extdata", "parameters",
-      package = "workflow.pacta.report"
-    ) ,
-    schema_file = system.file(
-      "extdata", "schema", "reportingParameters.json",
-      package = "workflow.pacta.report"
-    )
-  )
 
   # quit if there's no relevant PACTA assets -------------------------------------
 

--- a/R/run_pacta_reporting_process.R
+++ b/R/run_pacta_reporting_process.R
@@ -20,10 +20,20 @@ run_pacta_reporting_process <- function(
   if (is.null(report_output_dir) || report_output_dir == "") {
     log_error("REPORT_OUTPUT_DIR not set.")
     stop("REPORT_OUTPUT_DIR not set.")
+  } else {
+    if (!pacta.portfolio.utils::check_dir_writable(report_output_dir)) {
+      log_warn("Directory \"{report_output_dir}\" is not writable.")
+      stop("Directory \"{report_output_dir}\" is not writable.")
+    }
   }
   if (is.null(summary_output_dir) || summary_output_dir == "") {
     log_error("SUMMARY_OUTPUT_DIR not set.")
     stop("SUMMARY_OUTPUT_DIR not set.")
+  } else {
+    if (!pacta.portfolio.utils::check_dir_writable(summary_output_dir)) {
+      log_warn("Directory \"{report_output_dir}\" is not writable.")
+      stop("Directory \"{report_output_dir}\" is not writable.")
+    }
   }
   if (is.null(real_estate_dir) || real_estate_dir == "") {
     log_error("REAL_ESTATE_DIR not set.")

--- a/R/run_pacta_reporting_process.R
+++ b/R/run_pacta_reporting_process.R
@@ -97,8 +97,9 @@ run_pacta_reporting_process <- function(
   log_info("Loading PACTA results.")
 
   log_debug("Loading audit file.")
+  audit_file_path <- file.path(analysis_output_dir, "audit_file.rds")
   audit_file <- read_rds_or_return_alt_data(
-    filepath = file.path(analysis_output_dir, "audit_file.rds"),
+    filepath = audit_file_path,
     alt_return = pacta.portfolio.utils::empty_audit_file()
   )
   audit_file <- add_inv_and_port_names_if_needed(
@@ -108,8 +109,9 @@ run_pacta_reporting_process <- function(
   )
 
   log_debug("Loading portfolio overview.")
+  portfolio_overview_path <- file.path(analysis_output_dir, "overview_portfolio.rds")
   portfolio_overview <- read_rds_or_return_alt_data(
-    filepath = file.path(analysis_output_dir, "overview_portfolio.rds"),
+    filepath = portfolio_overview_path,
     alt_return = pacta.portfolio.utils::empty_portfolio_overview()
   )
   portfolio_overview <- add_inv_and_port_names_if_needed(
@@ -119,8 +121,9 @@ run_pacta_reporting_process <- function(
   )
 
   log_debug("Loading emissions.")
+  emissions_path <- file.path(analysis_output_dir, "emissions.rds")
   emissions <- read_rds_or_return_alt_data(
-    filepath = file.path(analysis_output_dir, "emissions.rds"),
+    filepath = emissions_path,
     alt_return = pacta.portfolio.utils::empty_emissions_results()
   )
   emissions <- add_inv_and_port_names_if_needed(
@@ -131,7 +134,7 @@ run_pacta_reporting_process <- function(
 
   log_debug("Loading total portfolio results.")
   total_portfolio <- read_rds_or_return_alt_data(
-    filepath = file.path(analysis_output_dir, "total_portfolio.rds"),
+    filepath = total_portfolio_path,
     alt_return = pacta.portfolio.utils::empty_portfolio_results()
   )
   total_portfolio <- add_inv_and_port_names_if_needed(
@@ -141,8 +144,12 @@ run_pacta_reporting_process <- function(
   )
 
   log_debug("Loading portfolio equity results.")
+  equity_results_portfolio_path <- file.path(
+    analysis_output_dir,
+    "Equity_results_portfolio.rds"
+  )
   equity_results_portfolio <- read_rds_or_return_alt_data(
-    filepath = file.path(analysis_output_dir, "Equity_results_portfolio.rds"),
+    filepath = equity_results_portfolio_path,
     alt_return = pacta.portfolio.utils::empty_portfolio_results()
   )
   equity_results_portfolio <- add_inv_and_port_names_if_needed(
@@ -152,8 +159,12 @@ run_pacta_reporting_process <- function(
   )
 
   log_debug("Loading portfolio bonds results.")
+  bonds_results_portfolio_path <- file.path(
+    analysis_output_dir,
+    "Bonds_results_portfolio.rds"
+  )
   bonds_results_portfolio <- read_rds_or_return_alt_data(
-    filepath = file.path(analysis_output_dir, "Bonds_results_portfolio.rds"),
+    filepath = bonds_results_portfolio_path,
     alt_return = pacta.portfolio.utils::empty_portfolio_results()
   )
   bonds_results_portfolio <- add_inv_and_port_names_if_needed(
@@ -163,8 +174,12 @@ run_pacta_reporting_process <- function(
   )
 
   log_debug("Loading company equity results.")
+  equity_results_company_path <- file.path(
+    analysis_output_dir,
+    "Equity_results_company.rds"
+  )
   equity_results_company <- read_rds_or_return_alt_data(
-    filepath = file.path(analysis_output_dir, "Equity_results_company.rds"),
+    filepath = equity_results_company_path,
     alt_return = pacta.portfolio.utils::empty_company_results()
   )
   equity_results_company <- add_inv_and_port_names_if_needed(
@@ -174,8 +189,12 @@ run_pacta_reporting_process <- function(
   )
 
   log_debug("Loading company bonds results.")
+  bonds_results_company_path <- file.path(
+    analysis_output_dir,
+    "Bonds_results_company.rds"
+  )
   bonds_results_company <- read_rds_or_return_alt_data(
-    filepath = file.path(analysis_output_dir, "Bonds_results_company.rds"),
+    filepath = bonds_results_company_path,
     alt_return = pacta.portfolio.utils::empty_company_results()
   )
   bonds_results_company <- add_inv_and_port_names_if_needed(
@@ -185,8 +204,12 @@ run_pacta_reporting_process <- function(
   )
 
   log_debug("Loading equity map results.")
+  equity_results_map_path <- file.path(
+    analysis_output_dir,
+    "Equity_results_map.rds"
+  )
   equity_results_map <- read_rds_or_return_alt_data(
-    filepath = file.path(analysis_output_dir, "Equity_results_map.rds"),
+    filepath = equity_results_map_path,
     alt_return = pacta.portfolio.utils::empty_map_results()
   )
   equity_results_map <- add_inv_and_port_names_if_needed(
@@ -196,8 +219,12 @@ run_pacta_reporting_process <- function(
   )
 
   log_debug("Loading bonds map results.")
+  bonds_results_map_path <- file.path(
+    analysis_output_dir,
+    "Bonds_results_map.rds"
+  )
   bonds_results_map <- read_rds_or_return_alt_data(
-    filepath = file.path(analysis_output_dir, "Bonds_results_map.rds"),
+    filepath = bonds_results_map_path,
     alt_return = pacta.portfolio.utils::empty_map_results()
   )
   bonds_results_map <- add_inv_and_port_names_if_needed(
@@ -206,61 +233,67 @@ run_pacta_reporting_process <- function(
     investor_name = params[["user"]][["name"]]
   )
 
-  analysis_output_manifest <- jsonlite::read_json(file.path(analysis_output_dir, "manifest.json"))
+  analysis_output_manifest <- jsonlite::read_json(analysis_manifest_path)
 
   log_debug("Loading portfolio equity peer results.")
+  peers_equity_results_portfolio_path <- file.path(
+    benchmarks_dir,
+    paste0(
+      params[["reporting"]][["projectCode"]],
+      "_peers_equity_results_portfolio.rds"
+    )
+  )
   peers_equity_results_portfolio <- read_rds_or_return_alt_data(
-    filepath = file.path(
-      benchmarks_dir,
-      paste0(
-        params[["reporting"]][["projectCode"]],
-        "_peers_equity_results_portfolio.rds"
-      )
-    ),
+    filepath = peers_equity_results_portfolio_path,
     alt_return = pacta.portfolio.utils::empty_portfolio_results()
   )
 
   log_debug("Loading portfolio bonds peer results.")
+  peers_bonds_results_portfolio_path <- file.path(
+    benchmarks_dir,
+    paste0(
+      params[["reporting"]][["projectCode"]],
+      "_peers_bonds_results_portfolio.rds"
+    )
+  )
   peers_bonds_results_portfolio <- read_rds_or_return_alt_data(
-    filepath = file.path(
-      benchmarks_dir,
-      paste0(
-        params[["reporting"]][["projectCode"]],
-        "_peers_bonds_results_portfolio.rds"
-      )
-    ),
+    filepath = peers_bonds_results_portfolio_path,
     alt_return = pacta.portfolio.utils::empty_portfolio_results()
   )
 
   log_debug("Loading index equity peer results.")
+  peers_equity_results_user_path <- file.path(
+    benchmarks_dir,
+    paste0(
+      params[["reporting"]][["projectCode"]],
+      "_peers_equity_results_portfolio_ind.rds"
+    )
+  )
   peers_equity_results_user <- read_rds_or_return_alt_data(
-    filepath = file.path(
-      benchmarks_dir,
-      paste0(
-        params[["reporting"]][["projectCode"]],
-        "_peers_equity_results_portfolio_ind.rds"
-      )
-    ),
+    filepath = peers_equity_results_user_path,
     alt_return = pacta.portfolio.utils::empty_portfolio_results()
   )
 
   log_debug("Loading index bonds peer results.")
+  peers_bonds_results_user_path <- file.path(
+    benchmarks_dir,
+    paste0(
+      params[["reporting"]][["projectCode"]],
+      "_peers_bonds_results_portfolio_ind.rds"
+    )
+  )
   peers_bonds_results_user <- read_rds_or_return_alt_data(
-    filepath = file.path(
-      benchmarks_dir,
-      paste0(
-        params[["reporting"]][["projectCode"]],
-        "_peers_bonds_results_portfolio_ind.rds"
-      )
-    ),
+    filepath = peers_bonds_results_user_path,
     alt_return = pacta.portfolio.utils::empty_portfolio_results()
   )
 
   log_debug("Loading index equity portfolio results.")
-  indices_equity_results_portfolio <- readRDS(file.path(benchmarks_dir, "Indices_equity_results_portfolio.rds"))
+  indices_equity_results_portfolio_path <- file.path(benchmarks_dir, "Indices_equity_results_portfolio.rds")
+  indices_equity_results_portfolio <- readRDS(indices_equity_results_portfolio_path)
 
   log_debug("Loading index bonds portfolio results.")
-  indices_bonds_results_portfolio <- readRDS(file.path(benchmarks_dir, "Indices_bonds_results_portfolio.rds"))
+  indices_bonds_results_portfolio_path <- file.path(benchmarks_dir, "Indices_bonds_results_portfolio.rds")
+  indices_bonds_results_portfolio <- readRDS(indices_bonds_results_portfolio_path)
 
   # create interactive report ----------------------------------------------------
 
@@ -329,4 +362,44 @@ run_pacta_reporting_process <- function(
   )
 
   log_info("Portfolio report finished.")
+  return(
+    list(
+      input_files = unique(
+        c(
+          analysis_manifest_path,
+          total_portfolio_path,
+          audit_file_path,
+          portfolio_overview_path,
+          emissions_path,
+          total_portfolio_path,
+          equity_results_portfolio_path,
+          bonds_results_portfolio_path,
+          equity_results_company_path,
+          bonds_results_company_path,
+          equity_results_map_path,
+          bonds_results_map_path,
+          analysis_manifest_path,
+          peers_equity_results_portfolio_path,
+          peers_bonds_results_portfolio_path,
+          peers_equity_results_user_path,
+          peers_bonds_results_user_path,
+          indices_equity_results_portfolio_path,
+          indices_bonds_results_portfolio_path
+        )
+      ),
+      output_files = c(
+        list.files(
+          report_output_dir,
+          full.names = TRUE,
+          recursive = TRUE
+          ),
+        list.files(
+          summary_output_dir,
+          full.names = TRUE,
+          recursive = TRUE
+        )
+        ),
+      params = params
+    )
+  )
 }

--- a/R/run_pacta_reporting_process.R
+++ b/R/run_pacta_reporting_process.R
@@ -362,31 +362,36 @@ run_pacta_reporting_process <- function(
   )
 
   log_info("Portfolio report finished.")
+
+  # Prepare manifest info
+  input_files <- unique(
+    c(
+      analysis_manifest_path,
+      total_portfolio_path,
+      audit_file_path,
+      portfolio_overview_path,
+      emissions_path,
+      total_portfolio_path,
+      equity_results_portfolio_path,
+      bonds_results_portfolio_path,
+      equity_results_company_path,
+      bonds_results_company_path,
+      equity_results_map_path,
+      bonds_results_map_path,
+      analysis_manifest_path,
+      peers_equity_results_portfolio_path,
+      peers_bonds_results_portfolio_path,
+      peers_equity_results_user_path,
+      peers_bonds_results_user_path,
+      indices_equity_results_port_path,
+      indices_bonds_results_port_path
+    )
+  )
+  input_files <- input_files[file.exists(input_files)]
+
   return(
     list(
-      input_files = unique(
-        c(
-          analysis_manifest_path,
-          total_portfolio_path,
-          audit_file_path,
-          portfolio_overview_path,
-          emissions_path,
-          total_portfolio_path,
-          equity_results_portfolio_path,
-          bonds_results_portfolio_path,
-          equity_results_company_path,
-          bonds_results_company_path,
-          equity_results_map_path,
-          bonds_results_map_path,
-          analysis_manifest_path,
-          peers_equity_results_portfolio_path,
-          peers_bonds_results_portfolio_path,
-          peers_equity_results_user_path,
-          peers_bonds_results_user_path,
-          indices_equity_results_port_path,
-          indices_bonds_results_port_path
-        )
-      ),
+      input_files = input_files,
       output_files = c(
         list.files(
           report_output_dir,

--- a/R/workflow.pacta.report-package.R
+++ b/R/workflow.pacta.report-package.R
@@ -1,6 +1,16 @@
 #' @keywords internal
 "_PACKAGE"
 
+# Supress lintr warnings about functions re-exported from logger
+utils::globalVariables(
+  c(
+    "log_debug",
+    "log_error",
+    "log_info",
+    "log_trace",
+    "log_warn"
+  )
+)
 ## usethis namespace: start
 #' @importFrom logger log_debug
 #' @importFrom logger log_error

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # stdin_open: true
     # tty: true
     # entrypoint: ["R", "--args"]
-    command: '{\"portfolio\": {\"files\": \"default_portfolio.csv\", \"holdingsDate\": \"2023-12-31\", \"name\": \"FooPortfolio\"}, \"inherit\": \"GENERAL_2023Q4\"}'
+    command: '{\"portfolio\": {\"files\": [\"default_portfolio.csv\"], \"holdingsDate\": \"2023-12-31\", \"name\": \"FooPortfolio\"}, \"inherit\": \"GENERAL_2023Q4\"}'
     environment:
       LOG_LEVEL: TRACE
       ANALYSIS_OUTPUT_DIR: "/mnt/analysis_output_dir"

--- a/inst/extdata/schema/portfolio.json
+++ b/inst/extdata/schema/portfolio.json
@@ -7,8 +7,12 @@
   "type": "object",
   "properties": {
     "files": {
-      "type": "string",
-      "description": "List of portfolio files to be analyzed."
+      "type": "array",
+      "description": "List of portfolio files to be analyzed.",
+      "items": {
+        "type": "string",
+        "description": "Path to the file."
+      }
     },
     "holdingsDate": {
       "type": "string",

--- a/inst/extdata/scripts/run_pacta_report.R
+++ b/inst/extdata/scripts/run_pacta_report.R
@@ -1,2 +1,22 @@
-logger::log_threshold(Sys.getenv("LOG_LEVEL", "WARN"))
-workflow.pacta.report:::run_pacta_reporting_process(commandArgs(trailingOnly = TRUE))
+logger::log_threshold(Sys.getenv("LOG_LEVEL", "INFO"))
+
+raw_params <- commandArgs(trailingOnly = TRUE)
+params <- pacta.workflow.utils::parse_raw_params(
+  json = raw_params,
+  inheritence_search_paths = system.file(
+    "extdata", "parameters",
+    package = "workflow.pacta.report"
+  ) ,
+  schema_file = system.file(
+    "extdata", "schema", "reportingParameters.json",
+    package = "workflow.pacta.report"
+  ),
+  raw_schema_file = system.file(
+    "extdata", "schema", "rawParameters.json",
+    package = "workflow.pacta.report"
+  )
+)
+
+workflow.pacta.report:::run_pacta_reporting_process(
+  params = params
+)

--- a/inst/extdata/scripts/run_pacta_report.R
+++ b/inst/extdata/scripts/run_pacta_report.R
@@ -17,6 +17,14 @@ params <- pacta.workflow.utils::parse_raw_params(
   )
 )
 
-workflow.pacta.report:::run_pacta_reporting_process(
+manifest_info <- workflow.pacta.report:::run_pacta_reporting_process(
   params = params
+)
+
+pacta.workflow.utils::export_manifest(
+  input_files = manifest_info[["input_files"]],
+  output_files = manifest_info[["output_files"]],
+  params = manifest_info[["params"]],
+  manifest_path = file.path(Sys.getenv("REPORT_OUTPUT_DIR"), "manifest.json"),
+  raw_params = raw_params
 )

--- a/tests/config/default_2022Q4.json
+++ b/tests/config/default_2022Q4.json
@@ -7,7 +7,9 @@
     "portfolio": {
       "holdingsDate": "2022-12-31",
       "name": "Default Portfolio",
-      "files": "default_portfolio.csv"
+      "files": [
+        "default_portfolio.csv"
+      ]
     },
     "inherit": "GENERAL_2022Q4"
   }

--- a/tests/config/default_2023Q4.json
+++ b/tests/config/default_2023Q4.json
@@ -7,7 +7,9 @@
     "portfolio": {
       "holdingsDate": "2023-12-31",
       "name": "Default Portfolio",
-      "files": "default_portfolio.csv"
+      "files": [
+        "default_portfolio.csv"
+      ]
     },
     "inherit": "GENERAL_2023Q4"
   }

--- a/tests/config/full_params_2023Q4.json
+++ b/tests/config/full_params_2023Q4.json
@@ -7,7 +7,9 @@
     "portfolio": {
       "holdingsDate": "2023-12-31",
       "name": "Default Portfolio",
-      "files": "default_portfolio.csv"
+      "files": [
+        "default_portfolio.csv"
+      ]
     },
     "user": {
       "name": "Default Investor",


### PR DESCRIPTION
- Parse parameters in calling script, and pass to function, rather than parse arguments inside a function
- Export manifest when creating a report
- Use the new parameters schema (array of filenames, not single string)