### PR TITLE
Command flow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: workflow.pacta.report
 Title: Reporting functionality for PACTA
-Version: 0.0.0.9008
+Version: 0.0.0.9009
 Authors@R: 
     c(person(given = "Alex",
              family = "Axthelm",

--- a/inst/extdata/parameters/report_default.json
+++ b/inst/extdata/parameters/report_default.json
@@ -1,4 +1,7 @@
 {
+  "commands": {
+    "report": true
+  },
   "reporting": {
     "scenarioGeography": "Global",
     "sectorList": [

--- a/inst/extdata/schema/reportingParameters.json
+++ b/inst/extdata/schema/reportingParameters.json
@@ -6,6 +6,19 @@
   "$comment": "Created by Alex Axthelm, aaxthelm@rmi.org",
   "type": "object",
   "properties": {
+    "commands": {
+      "type": "object",
+      "description": "Commands to run.",
+      "properties": {
+        "report": {
+          "type": "boolean",
+          "description": "Whether to create an interactive report."
+        }
+      },
+      "required": [
+        "report"
+      ]
+    },
     "portfolio": {
       "$ref": "portfolio.json"
     },
@@ -163,6 +176,7 @@
   "allOf": [
     {
       "required": [
+        "commands",
         "portfolio",
         "reporting",
         "user"

--- a/tests/config/full_params_2023Q4.json
+++ b/tests/config/full_params_2023Q4.json
@@ -4,6 +4,9 @@
   "resultsURL": "https://pactadatadev.blob.core.windows.net/ghactions-workflow-pacta-results/76/merge/latest/full_params_2023Q4/output_dir",
   "benchmarksURL": "https://pactadatadev.file.core.windows.net/workflow-prepare-pacta-indices-outputs/2023Q4_20240529T002355Z",
   "parameters": {
+    "commands": {
+      "report": true
+    },
     "portfolio": {
       "holdingsDate": "2023-12-31",
       "name": "Default Portfolio",


### PR DESCRIPTION
In support of https://github.com/RMI-PACTA/workflow.pacta.webapp/pull/33

Adds a (mandatory) `commands` object to JSON schema (with `report` object as a boolean value), which is used in `workflow.pacta.webapp` to control whether the interactive report is generated or not.